### PR TITLE
feat: add support for external_id to account config, pass along as an option to stscreds.NewAssumeRoleProvider

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -245,7 +245,13 @@ func Configure(logger hclog.Logger, providerConfig interface{}) (schema.ClientMe
 			if err != nil {
 				return nil, err
 			}
-			awsCfg.Credentials = stscreds.NewAssumeRoleProvider(sts.NewFromConfig(awsCfg), account.RoleARN)
+			opts := make([]func(*stscreds.AssumeRoleOptions), 0, 1)
+			if account.ExternalID != "" {
+				opts = append(opts, func(opts *stscreds.AssumeRoleOptions) {
+					opts.ExternalID = &account.ExternalID
+				})
+			}
+			awsCfg.Credentials = stscreds.NewAssumeRoleProvider(sts.NewFromConfig(awsCfg), account.RoleARN, opts...)
 		case account.ID != "default":
 			awsCfg, err = config.LoadDefaultConfig(
 				ctx,

--- a/client/config.go
+++ b/client/config.go
@@ -1,8 +1,9 @@
 package client
 
 type Account struct {
-	ID      string `hcl:",label"`
-	RoleARN string `hcl:"role_arn,optional"`
+	ID         string `hcl:",label"`
+	RoleARN    string `hcl:"role_arn,optional"`
+	ExternalID string `hcl:"external_id,optional"`
 }
 
 type Config struct {


### PR DESCRIPTION
example usage:
```hcl
provider "aws" {
  configuration {
    # Optional. If you want to assume roles in multiple accounts and fetch data from them
    accounts "<YOUR_ID>" {
      # Optional. Role ARN we want to assume when accessing this account
      role_arn = "<YOUR_ROLE_ARN>"
      # Optional. External ID to pass along when assuming specified role
      external_id = "<YOUR_EXTERNAL_ID>"
    }
    ...
  }
  ...
}
```

https://github.com/cloudquery/cq-provider-aws/pull/89